### PR TITLE
AGR-2528 Additional dockerhub => ECR code-changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALLIANCE_RELEASE=latest
-ARG REG=100225593120.dkr.ecr.us-east-1.amazonaws.com
+ARG REG=dockerhub
 FROM ${REG}/agr_base_linux_env:${ALLIANCE_RELEASE}
 
 WORKDIR /usr/src/ansible

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALLIANCE_RELEASE=latest
-ARG REG=dockerhub
+ARG REG=agrdocker
 FROM ${REG}/agr_base_linux_env:${ALLIANCE_RELEASE}
 
 WORKDIR /usr/src/ansible

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALLIANCE_RELEASE=latest
-ARG REG=agrdocker
+ARG REG=100225593120.dkr.ecr.us-east-1.amazonaws.com
 FROM ${REG}/agr_base_linux_env:${ALLIANCE_RELEASE}
 
 WORKDIR /usr/src/ansible

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
+REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+
 build: pull
-	docker build -t agrdocker/agr_ansible_run:latest .
+	docker build -t ${REG}/agr_ansible_run:latest --build-arg REG=${REG} .
 
 pull:
-	docker pull agrdocker/agr_base_linux_env:latest
+	docker pull ${REG}/agr_base_linux_env:latest
 
 bash:
-	docker run -it agrdocker/agr_ansible_run:latest bash
+	docker run -it ${REG}/agr_ansible_run:latest bash
 
 3_1_0:
-	docker run -it agrdocker/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.0 -i hosts launch_3.1.0.yml --vault-password-file=.password 
+	docker run -it ${REG}/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.0 -i hosts launch_3.1.0.yml --vault-password-file=.password
 
 3_1_1:
-	docker run -it agrdocker/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.1 -i hosts launch_3.1.1.yml --vault-password-file=.password 
+	docker run -it ${REG}/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.1 -i hosts launch_3.1.1.yml --vault-password-file=.password
 
 3_2_0:
-	docker run -it agrdocker/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.2.0 -i hosts launch_3.2.0.yml --vault-password-file=.password
+	docker run -it ${REG}/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.2.0 -i hosts launch_3.2.0.yml --vault-password-file=.password

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
 TAG := latest
 
 build: pull
-	docker build -t ${REG}/agr_ansible_run:${TAG} --build-arg REG=${REG} --build-arg ALLIANCE_RELEASE=${TAG} .
+	docker build -t agrlocal/agr_ansible_run_unlocked:${TAG} --build-arg REG=${REG} --build-arg ALLIANCE_RELEASE=${TAG} .
 
 pull:
 	docker pull ${REG}/agr_base_linux_env:${TAG}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+AWS_PROFILE ?= default
 TAG := latest
 
 build: pull
 	docker build -t agrlocal/agr_ansible_run_unlocked:${TAG} --build-arg REG=${REG} --build-arg ALLIANCE_RELEASE=${TAG} .
 
-pull:
+registry-docker-login:
+ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
+	aws --profile ${AWS_PROFILE} ecr get-login-password | docker login -u AWS --password-stdin https://${REG}
+endif
+
+pull: registry-docker-login
 	docker pull ${REG}/agr_base_linux_env:${TAG}
 
 bash:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
-AWS_PROFILE ?= default
 TAG := latest
 
 build: pull
@@ -7,7 +6,12 @@ build: pull
 
 registry-docker-login:
 ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
-	aws --profile ${AWS_PROFILE} ecr get-login-password | docker login -u AWS --password-stdin https://${REG}
+	@$(eval DOCKER_LOGIN_CMD=aws)
+ifneq (${AWS_PROFILE},)
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} --profile ${AWS_PROFILE})
+endif
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} ecr get-login-password | docker login -u AWS --password-stdin https://${REG})
+	${DOCKER_LOGIN_CMD}
 endif
 
 pull: registry-docker-login

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+TAG := latest
 
 build: pull
-	docker build -t ${REG}/agr_ansible_run:latest --build-arg REG=${REG} .
+	docker build -t ${REG}/agr_ansible_run:${TAG} --build-arg REG=${REG} --build-arg ALLIANCE_RELEASE=${TAG} .
 
 pull:
-	docker pull ${REG}/agr_base_linux_env:latest
+	docker pull ${REG}/agr_base_linux_env:${TAG}
 
 bash:
-	docker run -it ${REG}/agr_ansible_run:latest bash
+	docker run -it ${REG}/agr_ansible_run:${TAG} bash
 
 3_1_0:
-	docker run -it ${REG}/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.0 -i hosts launch_3.1.0.yml --vault-password-file=.password
+	docker run -it ${REG}/agr_ansible_run:${TAG} ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.0 -i hosts launch_3.1.0.yml --vault-password-file=.password
 
 3_1_1:
-	docker run -it ${REG}/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.1 -i hosts launch_3.1.1.yml --vault-password-file=.password
+	docker run -it ${REG}/agr_ansible_run:${TAG} ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.1.1 -i hosts launch_3.1.1.yml --vault-password-file=.password
 
 3_2_0:
-	docker run -it ${REG}/agr_ansible_run:latest ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.2.0 -i hosts launch_3.2.0.yml --vault-password-file=.password
+	docker run -it ${REG}/agr_ansible_run:${TAG} ansible-playbook -e env=production -e ALLIANCE_RELEASE=3.2.0 -i hosts launch_3.2.0.yml --vault-password-file=.password


### PR DESCRIPTION
As the GoCD pipelines have been updated to push all new docker images to ECR, all scripts currently still pulling from dockerhub should be adjusted accordingly.
Here I updated the Makefile to use the ECR base image upon executing `make build` or `make pull`. The makefile automatically handles the required ECR login, provided you have the AWS CLI installed and either have:
 * The required AWS profile saved through the AWS CLI (see [aws docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html), you can use named profile by defining the AWS_PROFILE env variable)
 * Provided credentials details through env variables (see [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html))
 * The required permission granted through an EC2 instance role (on EC2 instances only)
