### PR TITLE
Fix undefined AWS_PRODUCT_TAG and AWS_ENV_TAG in playbook_launch_instance

### DIFF
--- a/environments/shared_aws_instance_variables.yml
+++ b/environments/shared_aws_instance_variables.yml
@@ -4,6 +4,10 @@
 
 # AWS Variables
 COMPUTE_INSTANCE_TYPE: "{{ lookup('env','COMPUTE_INSTANCE_TYPE') or 'r5d.8xlarge' }}"
+
+# AWS Instance Tagging (used by playbooks that don't load shared_variables.yml)
+AWS_PRODUCT_TAG: "{{ lookup('env','AWS_PRODUCT_TAG') | default('Ansible - untagged: PLAYBOOK_NAME',True) }}"
+AWS_ENV_TAG: "{{ lookup('env','AWS_ENV_TAG') | default('Ansible - untagged: PLAYBOOK_NAME',True) }}"
 COMPUTE_AMI_IMAGE: ami-05668c1bb69ebd078
 WEBSERVER_INSTANCE_TYPE: "{{ lookup('env','WEBSERVER_INSTANCE_TYPE') or 'r5a.large' }}"
 WEBSERVER_AMI_IMAGE: "{{ lookup('env','WEBSERVER_AMI_IMAGE') or 'ami-05668c1bb69ebd078' }}"


### PR DESCRIPTION
## Summary

- Add `AWS_PRODUCT_TAG` and `AWS_ENV_TAG` to `shared_aws_instance_variables.yml`

The AWS tagging variables added in SCRUM-5224 (commit 5fe488c) were only defined in `shared_variables.yml`, but `playbook_launch_instance.yml` loads `shared_aws_instance_variables.yml` instead. This caused all playbooks using `playbook_launch_instance.yml` to fail with:

```
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. 
The error was: 'AWS_PRODUCT_TAG' is undefined...
```

This is blocking LoaderPR pipeline jobs (and likely other pipelines).

## Test plan

- [ ] Verify LoaderPR pipeline jobs can now launch EC2 instances without the undefined variable error
- [ ] Confirm EC2 instances and volumes are properly tagged with Product and DeploymentEnvironment tags