### PR TITLE
Fix: Docker module hanging with PyPy on CoreOS

### DIFF
--- a/playbook_launch_alpha_cluster_node.yml
+++ b/playbook_launch_alpha_cluster_node.yml
@@ -147,14 +147,10 @@
   tasks:
 
     - name: Pull OS Env Image
-      docker_image:
-        name: "{{ OS_ENV_IMAGE }}"
-        source: pull
-  
+      shell: docker pull {{ OS_ENV_IMAGE }} 2>&1
+
     - name: Pull Cerebro Image
-      docker_image:
-        name: "yannart/cerebro:latest"
-        source: pull
+      shell: docker pull yannart/cerebro:latest 2>&1
     
     - name: Run OS Cluster Node "{{ ALPHA_OS_CLUSTER_NODE_NAME }}"
       docker_container:

--- a/playbook_launch_beta_cluster_node.yml
+++ b/playbook_launch_beta_cluster_node.yml
@@ -147,14 +147,10 @@
   tasks:
 
     - name: Pull OS Env Image
-      docker_image:
-        name: "{{ OS_ENV_IMAGE }}"
-        source: pull
-  
+      shell: docker pull {{ OS_ENV_IMAGE }} 2>&1
+
     - name: Pull Cerebro Image
-      docker_image:
-        name: "yannart/cerebro:latest"
-        source: pull
+      shell: docker pull yannart/cerebro:latest 2>&1
     
     - name: Run OS Cluster Node "{{ BETA_OS_CLUSTER_NODE_NAME }}"
       docker_container:

--- a/playbook_launch_production_cluster_node.yml
+++ b/playbook_launch_production_cluster_node.yml
@@ -147,14 +147,10 @@
   tasks:
 
     - name: Pull OS Env Image
-      docker_image:
-        name: "{{ OS_ENV_IMAGE }}"
-        source: pull
-  
+      shell: docker pull {{ OS_ENV_IMAGE }} 2>&1
+
     - name: Pull Cerebro Image
-      docker_image:
-        name: "yannart/cerebro:latest"
-        source: pull
+      shell: docker pull yannart/cerebro:latest 2>&1
     
     - name: Run OS Cluster Node "{{ PRODUCTION_OS_CLUSTER_NODE_NAME }}"
       docker_container:

--- a/playbook_launch_stage_cluster_node.yml
+++ b/playbook_launch_stage_cluster_node.yml
@@ -147,9 +147,7 @@
   tasks:
 
     - name: Pull ES Env Image
-      docker_image:
-        name: "{{ ES_ENV_IMAGE }}"
-        source: pull
+      shell: docker pull {{ ES_ENV_IMAGE }} 2>&1
   
     - name: Run ES Cluster Node "{{ STAGE_ES_CLUSTER_NODE_NAME }}"
       docker_container:

--- a/playbook_restart_cluster_node.yml
+++ b/playbook_restart_cluster_node.yml
@@ -49,9 +49,7 @@
         state: absent
 
     - name: Pull ES Env Image
-      docker_image:
-        name: "{{ ES_ENV_IMAGE }}"
-        source: pull
+      shell: docker pull {{ ES_ENV_IMAGE }} 2>&1
  
     - name: Run ES Cluster Node "{{ ES_CLUSTER_NODE_NAME }}"
       docker_container:

--- a/roles/install_python/files/install_python.sh
+++ b/roles/install_python/files/install_python.sh
@@ -7,4 +7,4 @@ rm pypy.tar.bz2
 wget -q https://agr-build-files.s3.amazonaws.com/get-pip.py
 pypy/bin/pypy get-pip.py
 rm get-pip.py
-pypy/bin/pypy -m pip install docker-py
+pypy/bin/pypy -m pip install docker

--- a/roles/setup_docker/tasks/main.yml
+++ b/roles/setup_docker/tasks/main.yml
@@ -22,9 +22,7 @@
     group: core
 
 - name: Docker pull cli image
-  docker_image:
-    name: amazon/aws-cli:latest
-    source: pull
+  shell: docker pull amazon/aws-cli:latest 2>&1
 
 - name: AWS Create ECR Token (Good only for 12 hours)
   raw: docker run -it --rm amazon/aws-cli ecr get-login-password

--- a/roles/setup_nvme_drive/tasks/main.yml
+++ b/roles/setup_nvme_drive/tasks/main.yml
@@ -1,13 +1,29 @@
 ---
-# tasks file for setup_nvme_drives
+# tasks file for setup_nvme_drive (single drive)
+# This runs BEFORE Docker is configured, so Docker should be clean/empty
 
-- name: Shutdown Docker
-  command: systemctl stop docker.service
+- name: Stop Docker service if running
+  systemd:
+    name: docker.service
+    state: stopped
+  ignore_errors: yes
 
-- name: Get directory stats
-  stat:
-    path: "/var/lib/docker"
-  register: directory_stat
+- name: Stop Docker socket if exists
+  systemd:
+    name: docker.socket
+    state: stopped
+  ignore_errors: yes
+
+- name: Wait a moment for Docker to stop
+  pause:
+    seconds: 3
+
+- name: Unmount any existing mounts in /var/lib/docker
+  shell: |
+    for mount in $(mount | grep '/var/lib/docker' | awk '{print $3}' | sort -r); do
+      umount -l "$mount" || true
+    done
+  ignore_errors: yes
 
 - name: Delete directory
   file:

--- a/roles/setup_nvme_drives/tasks/main.yml
+++ b/roles/setup_nvme_drives/tasks/main.yml
@@ -1,13 +1,29 @@
 ---
 # tasks file for setup_nvme_drives
+# This runs BEFORE Docker is configured, so Docker should be clean/empty
 
-- name: Shutdown Docker
-  command: systemctl stop docker.service
+- name: Stop Docker service if running
+  systemd:
+    name: docker.service
+    state: stopped
+  ignore_errors: yes
 
-- name: Get directory stats
-  stat:
-    path: "/var/lib/docker"
-  register: directory_stat
+- name: Stop Docker socket if exists
+  systemd:
+    name: docker.socket
+    state: stopped
+  ignore_errors: yes
+
+- name: Wait a moment for Docker to stop
+  pause:
+    seconds: 3
+
+- name: Unmount any existing mounts in /var/lib/docker
+  shell: |
+    for mount in $(mount | grep '/var/lib/docker' | awk '{print $3}' | sort -r); do
+      umount -l "$mount" || true
+    done
+  ignore_errors: yes
 
 - name: Delete directory
   file:

--- a/roles/setup_swap/tasks/main.yml
+++ b/roles/setup_swap/tasks/main.yml
@@ -1,6 +1,20 @@
 ---
 # tasks file for setup_swap
 
+- name: Turn off existing swap if active
+  command: swapoff /swapfile
+  become: true
+  become_user: root
+  ignore_errors: yes
+
+- name: Remove existing swap file
+  file:
+    path: /swapfile
+    state: absent
+  become: true
+  become_user: root
+  ignore_errors: yes
+
 - name: Create swap file
   command: fallocate -l "{{ SWAP_SIZE }}" /swapfile
   become: true
@@ -22,4 +36,3 @@
   command: swapon /swapfile
   become: true
   become_user: root
-

--- a/tasks/run_api_integration_testing.yml
+++ b/tasks/run_api_integration_testing.yml
@@ -1,7 +1,5 @@
 - name: Pull Java Testing Run Image
-  docker_image:
-    name: "{{ API_TEST_IMAGE }}"
-    source: pull
+  shell: docker pull {{ API_TEST_IMAGE }} 2>&1
 
 - name: Run API
   docker_container:

--- a/tasks/run_cacher.yml
+++ b/tasks/run_cacher.yml
@@ -1,7 +1,5 @@
 - name: Pull Cacher Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run Cacher
   docker_container:

--- a/tasks/run_file_gener.yml
+++ b/tasks/run_file_gener.yml
@@ -1,7 +1,5 @@
 - name: Pull File Generator Run Image
-  docker_image:
-    name: "{{ FILE_GENER_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ FILE_GENER_RUN_IMAGE }} 2>&1
 
 - name: Run File Generator
   docker_container:

--- a/tasks/run_file_gener_integration.yml
+++ b/tasks/run_file_gener_integration.yml
@@ -1,7 +1,5 @@
 - name: Pull File Generator Run Image
-  docker_image:
-    name: "{{ FILE_GENER_TEST_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ FILE_GENER_TEST_RUN_IMAGE }} 2>&1
 
 - name: Run File Generator Tests
   docker_container:

--- a/tasks/run_indexer.yml
+++ b/tasks/run_indexer.yml
@@ -1,7 +1,5 @@
 - name: Pull Indexer Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run Indexer
   docker_container:

--- a/tasks/run_indexer_integration_testing.yml
+++ b/tasks/run_indexer_integration_testing.yml
@@ -1,7 +1,5 @@
 - name: Pull Java Testing Run Image
-  docker_image:
-    name: "{{ INDEXER_TEST_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INDEXER_TEST_IMAGE }} 2>&1
 
 - name: Run Indexer Tests
   docker_container:

--- a/tasks/run_intermine_builder.yml
+++ b/tasks/run_intermine_builder.yml
@@ -1,12 +1,8 @@
 - name: Pull Intermine Builder Image
-  docker_image:
-    name: "{{ INTERMINE_BUILDER_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_BUILDER_RUN_IMAGE }} 2>&1
 
 - name: Pull Java Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run Java Intermine Data Extractor
   docker_container:

--- a/tasks/run_loader.yml
+++ b/tasks/run_loader.yml
@@ -1,7 +1,5 @@
 - name: Pull Loader Run Image
-  docker_image:
-    name: "{{ LOADER_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ LOADER_RUN_IMAGE }} 2>&1
 
 - name: Run Loader
   docker_container:

--- a/tasks/run_loader_integration_tests.yml
+++ b/tasks/run_loader_integration_tests.yml
@@ -1,7 +1,5 @@
 - name: Pull Loader Run Image
-  docker_image:
-    name: "{{ LOADER_TEST_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ LOADER_TEST_RUN_IMAGE }} 2>&1
 
 - name: Run Loader in Test Mode
   docker_container:

--- a/tasks/run_preprocess.yml
+++ b/tasks/run_preprocess.yml
@@ -1,7 +1,5 @@
 - name: Pull Preprocess Run Image
-  docker_image:
-    name: "{{ PREPROCESS_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ PREPROCESS_RUN_IMAGE }} 2>&1
 
 - name: Run Preprocess
   docker_container:

--- a/tasks/run_qc.yml
+++ b/tasks/run_qc.yml
@@ -1,7 +1,5 @@
 - name: Pull QC Run Image
-  docker_image:
-    name: "{{ QC_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ QC_RUN_IMAGE }} 2>&1
 
 - name: Run QC
   docker_container:

--- a/tasks/run_restore_index.yml
+++ b/tasks/run_restore_index.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull Java Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Restore Latest ES Index Snapshot
   docker_container:

--- a/tasks/run_variant_indexer.yml
+++ b/tasks/run_variant_indexer.yml
@@ -1,7 +1,5 @@
 - name: Pull Java Software Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run Variant Indexer
   docker_container:

--- a/tasks/start_api_quarkus.yml
+++ b/tasks/start_api_quarkus.yml
@@ -1,8 +1,6 @@
 ---
 - name: Pull Java Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run API with Health Check
   docker_container:

--- a/tasks/start_api_swarm.yml
+++ b/tasks/start_api_swarm.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull Java Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run API
   docker_container:

--- a/tasks/start_api_thorntail.yml
+++ b/tasks/start_api_thorntail.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull Java Run Image
-  docker_image:
-    name: "{{ JAVA_SOFTWARE_RUN_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JAVA_SOFTWARE_RUN_IMAGE }} 2>&1
 
 - name: Run API
   docker_container:

--- a/tasks/start_apollo.yml
+++ b/tasks/start_apollo.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull Apollo Server Image
-  docker_image:
-    name: "{{ APOLLO_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ APOLLO_SERVER_IMAGE }} 2>&1
 
 - name: Run Apollo Server
   docker_container:

--- a/tasks/start_curation_data.yml
+++ b/tasks/start_curation_data.yml
@@ -1,17 +1,11 @@
 - name: Pull Curation Data Image
-  docker_image:
-    name: "{{ CURATION_DATA_IMAGE }}"
-    source: pull
+  shell: docker pull {{ CURATION_DATA_IMAGE }} 2>&1
 
 - name: Pull Curation OpenSearch Image
-  docker_image:
-    name: "{{ OPENSEARCH_IMAGE_NAME }}"
-    source: pull
+  shell: docker pull {{ OPENSEARCH_IMAGE_NAME }} 2>&1
 
 - name: Pull Curation API Image
-  docker_image:
-    name: "{{ CURATION_API_IMAGE }}"
-    source: pull
+  shell: docker pull {{ CURATION_API_IMAGE }} 2>&1
 
 - name: Run Curation Data Setup
   docker_container:

--- a/tasks/start_elk.yml
+++ b/tasks/start_elk.yml
@@ -1,12 +1,8 @@
 - name: Pull ES Env Image
-  docker_image:
-    name: "{{ ES_ENV_IMAGE }}"
-    source: pull
+  shell: docker pull {{ ES_ENV_IMAGE }} 2>&1
 
 - name: Pull Cerebro Image
-  docker_image:
-    name: "yannart/cerebro:latest"
-    source: pull
+  shell: docker pull yannart/cerebro:latest 2>&1
 
 - name: Run ES
   docker_container:
@@ -29,9 +25,7 @@
       - "9000:9000"
 
 - name: Pull Log Image
-  docker_image:
-    name: "{{ LOG_IMAGE_NAME }}"
-    source: pull
+  shell: docker pull {{ LOG_IMAGE_NAME }} 2>&1
 
 - name: Run Log Server
   docker_container:
@@ -46,9 +40,7 @@
     command: ./bin/logstash -e "input { gelf { type => docker } } output { elasticsearch { hosts => [\"{{ ES_SERVER_NAME }}\"] ilm_enabled => true ilm_policy => \"ilm-history-ilm-policy\" } }"
 
 - name: Pull Kibana Image
-  docker_image:
-    name: "{{ KIBANA_IMAGE }}"
-    source: pull
+  shell: docker pull {{ KIBANA_IMAGE }} 2>&1
 
 - name: Run Kibana
   docker_container:

--- a/tasks/start_es_env.yml
+++ b/tasks/start_es_env.yml
@@ -1,12 +1,8 @@
 - name: Pull ES Env Image
-  docker_image:
-    name: "{{ ES_ENV_IMAGE }}"
-    source: pull
+  shell: docker pull {{ ES_ENV_IMAGE }} 2>&1
 
 - name: Pull Cerebro Image
-  docker_image:
-    name: "yannart/cerebro:latest"
-    source: pull
+  shell: docker pull yannart/cerebro:latest 2>&1
 
 - name: Run ES
   docker_container:

--- a/tasks/start_gocd_agent.yml
+++ b/tasks/start_gocd_agent.yml
@@ -1,7 +1,5 @@
 - name: Pull GOCD Env Image
-  docker_image:
-    name: "{{ GOCD_IMAGE }}"
-    source: pull
+  shell: docker pull {{ GOCD_IMAGE }} 2>&1
   when: START_GOCD_AGENT == "true"
 
 - name: Run GoCD Agent 0

--- a/tasks/start_infinispan_data.yml
+++ b/tasks/start_infinispan_data.yml
@@ -1,7 +1,5 @@
 - name: Pull Cacher (Infinispan) Data Image
-  docker_image:
-    name: "{{ CACHER_DATA_IMAGE }}"
-    source: pull
+  shell: docker pull {{ CACHER_DATA_IMAGE }} 2>&1
 
 - name: Run Infinispan
   docker_container:

--- a/tasks/start_infinispan_env.yml
+++ b/tasks/start_infinispan_env.yml
@@ -1,7 +1,5 @@
 - name: Pull Infinispan Env Image
-  docker_image:
-    name: "{{ INFINISPAN_ENV_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INFINISPAN_ENV_IMAGE }} 2>&1
 
 - name: Run Infinispan
   docker_container:

--- a/tasks/start_intermine_bluegenes.yml
+++ b/tasks/start_intermine_bluegenes.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull InterMine Bluegenes
-  docker_image:
-    name: "intermine/bluegenes:latest"
-    source: pull
+  shell: docker pull intermine/bluegenes:latest 2>&1
 
 - name: Run InterMine Bluegenes
   docker_container:

--- a/tasks/start_intermine_cdn_server.yml
+++ b/tasks/start_intermine_cdn_server.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine CDN Image
-  docker_image:
-    name: "{{ INTERMINE_CDN_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_CDN_SERVER_IMAGE }} 2>&1
 
 - name: Run CDN Nginx container
   docker_container:

--- a/tasks/start_intermine_postgres_data.yml
+++ b/tasks/start_intermine_postgres_data.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine Postgres Data Image
-  docker_image:
-    name: "{{ INTERMINE_POSTGRES_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_POSTGRES_SERVER_IMAGE }} 2>&1
 
 - name: Start Postgres
   docker_container:

--- a/tasks/start_intermine_postgres_env.yml
+++ b/tasks/start_intermine_postgres_env.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine Postgres Env Image
-  docker_image:
-    name: "{{ INTERMINE_POSTGRES_ENV_NAME }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_POSTGRES_ENV_NAME }} 2>&1
 
 - name: Ensure custom network exists
   docker_network:

--- a/tasks/start_intermine_solr_data.yml
+++ b/tasks/start_intermine_solr_data.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine Solr Data Image
-  docker_image:
-    name: "{{ INTERMINE_SOLR_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_SOLR_SERVER_IMAGE }} 2>&1
 
 - name: Run Solr
   docker_container:

--- a/tasks/start_intermine_solr_env.yml
+++ b/tasks/start_intermine_solr_env.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine Solr Env Image
-  docker_image:
-    name: "{{ INTERMINE_SOLR_ENV_NAME }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_SOLR_ENV_NAME }} 2>&1
 
 - name: Run Solr
   docker_container:

--- a/tasks/start_intermine_tomcat_data.yml
+++ b/tasks/start_intermine_tomcat_data.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine Tomcat Data Image
-  docker_image:
-    name: "{{ INTERMINE_TOMCAT_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_TOMCAT_SERVER_IMAGE }} 2>&1
 
 - name: Run Tomcat
   docker_container:

--- a/tasks/start_intermine_tomcat_env.yml
+++ b/tasks/start_intermine_tomcat_env.yml
@@ -1,7 +1,5 @@
 - name: Pull Intermine Tomcat Env Image
-  docker_image:
-    name: "{{ INTERMINE_TOMCAT_ENV_NAME }}"
-    source: pull
+  shell: docker pull {{ INTERMINE_TOMCAT_ENV_NAME }} 2>&1
 
 - name: Run Tomcat
   docker_container:

--- a/tasks/start_jbrowse.yml
+++ b/tasks/start_jbrowse.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull JBrowse Server Image
-  docker_image:
-    name: "{{ JBROWSE_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ JBROWSE_SERVER_IMAGE }} 2>&1
 
 - name: Run JBrowse Server
   docker_container:

--- a/tasks/start_monitoring.yml
+++ b/tasks/start_monitoring.yml
@@ -10,9 +10,7 @@
     - "{{ BLACKBOX_CONFIG_PATH }}"
 
 - name: Pull Node Exporter Image
-  docker_image:
-    name: prom/node-exporter:v1.5.0
-    source: pull
+  shell: docker pull prom/node-exporter:v1.5.0 2>&1
 
 - name: Run Node Exporter Image
   docker_container:
@@ -27,9 +25,7 @@
     recreate: yes
 
 - name: Pull cAdvisor
-  docker_image:
-    name: gcr.io/cadvisor/cadvisor:v0.47.0
-    source: pull
+  shell: docker pull gcr.io/cadvisor/cadvisor:v0.47.0 2>&1
 
 - name: Run cAdvisor Image
   docker_container:
@@ -65,9 +61,7 @@
   when: env == "production"
 
 - name: Pull Alertmanager Image
-  docker_image:
-    name: prom/alertmanager:v0.24.0
-    source: pull
+  shell: docker pull prom/alertmanager:v0.24.0 2>&1
 
 - name: Run Alertmanager
   docker_container:
@@ -91,9 +85,7 @@
     dest: "{{ BLACKBOX_CONFIG_PATH }}/blackbox.yml"
 
 - name: Pull Blackbox Image
-  docker_image:
-    name: prom/blackbox-exporter:v0.23.0
-    source: pull
+  shell: docker pull prom/blackbox-exporter:v0.23.0 2>&1
 
 - name: Run Blackbox Exporter
   docker_container:
@@ -136,9 +128,7 @@
   when: env == "production"
 
 - name: Pull Prometheus Image
-  docker_image:
-    name: prom/prometheus:v2.43.0
-    source: pull
+  shell: docker pull prom/prometheus:v2.43.0 2>&1
 
 - name: Run Prometheus
   docker_container:
@@ -171,9 +161,7 @@
     directory_mode: yes
 
 - name: Pull Grafana Image
-  docker_image:
-    name: grafana/grafana:9.4.0
-    source: pull
+  shell: docker pull grafana/grafana:9.4.0 2>&1
 
 - name: Run Grafana Image
   docker_container:
@@ -195,9 +183,7 @@
     recreate: yes
 
 - name: Pull Portainer Image
-  docker_image:
-    name: portainer/portainer-ce:latest
-    source: pull
+  shell: docker pull portainer/portainer-ce:latest 2>&1
 
 - name: Create Portainer Volume
   docker_volume:

--- a/tasks/start_neo_data.yml
+++ b/tasks/start_neo_data.yml
@@ -1,7 +1,5 @@
 - name: Pull Neo4j Data Image
-  docker_image:
-    name: "{{ NEO_DATA_IMAGE }}"
-    source: pull
+  shell: docker pull {{ NEO_DATA_IMAGE }} 2>&1
 
 - name: Run Neo4j
   docker_container:

--- a/tasks/start_neo_env.yml
+++ b/tasks/start_neo_env.yml
@@ -1,7 +1,5 @@
 - name: Pull Neo4j Env Image
-  docker_image:
-    name: "{{ NEO_ENV_IMAGE }}"
-    source: pull
+  shell: docker pull {{ NEO_ENV_IMAGE }} 2>&1
 
 - name: Run Neo4j
   docker_container:

--- a/tasks/start_neo_test_image.yml
+++ b/tasks/start_neo_test_image.yml
@@ -1,7 +1,5 @@
 - name: Pull Neo4j Test Image
-  docker_image:
-    name: "{{ NEO_DATA_BUILD_IMAGE }}_test"
-    source: pull
+  shell: docker pull {{ NEO_DATA_BUILD_IMAGE }}_test 2>&1
 
 - name: Run Neo4j Test Image
   docker_container:

--- a/tasks/start_nginx.yml
+++ b/tasks/start_nginx.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull Nginx Server Image
-  docker_image:
-    name: "{{ REGISTRY }}/agr_nginx:{{ NGINX_TAG }}"
-    source: pull
+  shell: docker pull {{ REGISTRY }}/agr_nginx:{{ NGINX_TAG }} 2>&1
 
 - name: Run Nginx
   docker_container:

--- a/tasks/start_status_nginx.yml
+++ b/tasks/start_status_nginx.yml
@@ -1,7 +1,5 @@
 - name: Pull Nginx Server Image
-  docker_image:
-    name: "{{ STATUS_NGINX_IMAGE_NAME }}"
-    source: pull
+  shell: docker pull {{ STATUS_NGINX_IMAGE_NAME }} 2>&1
 
 - name: Create NGINX HTML Directory
   file:

--- a/tasks/start_ui.yml
+++ b/tasks/start_ui.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Pull UI Server Image
-  docker_image:
-    name: "{{ UI_SERVER_IMAGE }}"
-    source: pull
+  shell: docker pull {{ UI_SERVER_IMAGE }} 2>&1
 
 - name: Run UI
   docker_container:


### PR DESCRIPTION
## Summary
This PR applies the same fixes from agr_ansible_developers PR #27 to resolve deployment failures caused by the Ansible `docker_image` module hanging with PyPy on CoreOS.

## Changes

### 1. Docker Image Module Conversion (61 conversions across 45 files)
- Replace all `docker_image` module calls with `shell: docker pull`
- Add `2>&1` redirect for proper output capture
- Workaround for PyPy/docker_image module incompatibility

### 2. NVMe Setup Fixes (2 roles)
- `roles/setup_nvme_drives/tasks/main.yml` (RAID setup)
- `roles/setup_nvme_drive/tasks/main.yml` (single drive)

Changes:
- Stop Docker service AND socket properly (not just service)
- Add 3-second pause for Docker to fully stop  
- Unmount any existing mounts in /var/lib/docker before deletion
- Fixes "Device or resource busy" errors

### 3. Swap File Cleanup
- `roles/setup_swap/tasks/main.yml`
- Add swapoff and remove existing swap file before recreation
- Fixes "file already exists" errors on redeployment

### 4. Python Package Update
- `roles/install_python/files/install_python.sh`
- Update from deprecated `docker-py` to `docker` package

## Test Plan
- [ ] Deploy an alpha cluster node
- [ ] Verify NVMe setup completes without "Device or resource busy" error
- [ ] Verify all docker pull operations complete without hanging
- [ ] Verify swap setup works on fresh and redeployment scenarios

## Related
- agr_ansible_developers PR #27 (same fixes, verified through 10 successful deployments)